### PR TITLE
Update presign-url-s3-upload.MD - S3 Signature V4

### DIFF
--- a/presign-url-s3-upload.MD
+++ b/presign-url-s3-upload.MD
@@ -19,6 +19,7 @@ s3 = boto3.client(
    's3',
    aws_access_key_id='AKIAIO5FODNN7EXAMPLE',
    aws_secret_access_key='ABCDEF+c2L7yXeGvUyrPgYsDnWRRC1AYEXAMPLE'
+   config=Config(signature_version='s3v4'
 ) 
 """
 


### PR DESCRIPTION
Removes: The authorization mechanism you have provided is not supported. Please use AWS4-HMAC-SHA256